### PR TITLE
Fix Vue warning with .native modifier for v-on

### DIFF
--- a/src/vue-numeric-input.vue
+++ b/src/vue-numeric-input.vue
@@ -24,8 +24,8 @@
         v-if="controls"
         class="btn btn-decrement"
         @mousedown="start(decrement)"
-        @touchstart.native.prevent="start(decrement)"
-        @touchend.native.prevent="stop"
+        @touchstart="$event.preventDefault(); start(decrement)"
+        @touchend="$event.preventDefault(); stop($event)"
         :disabled="disabled || numericValue <= min"
       >
         <i class="btn-icon"></i>
@@ -35,8 +35,8 @@
         v-if="controls"
         class="btn btn-increment"
         @mousedown="start(increment)"
-        @touchstart.native.prevent="start(increment)"
-        @touchend.native.prevent="stop"
+        @touchstart="$event.preventDefault(); start(increment)"
+        @touchend="$event.preventDefault(); stop($event)"
         :disabled="disabled || numericValue >= max"
       >
         <i class="btn-icon"></i>


### PR DESCRIPTION
This PR fixes issue https://github.com/JayeshLab/vue-numeric-input/issues/12, avoiding Vue warning `The .native modifier for v-on is only valid on components but it was used on <button>`

Thank you so much for your good job @JayeshLab